### PR TITLE
Fix missing @throws tags, unwrap unnecessary curly braces

### DIFF
--- a/src/NowPaymentsClient.php
+++ b/src/NowPaymentsClient.php
@@ -4,6 +4,7 @@ namespace NowPayments;
 
 use GuzzleHttp\Client as HttpClient;
 use GuzzleHttp\ClientInterface;
+use NowPayments\Exception\ApiException;
 use NowPayments\Services\PaymentsService;
 use NowPayments\Services\SubscriptionsService;
 use NowPayments\Services\PayoutsService;
@@ -168,6 +169,7 @@ class NowPaymentsClient
 
     /**
      * Check API status
+     * @throws ApiException
      */
     public function getStatus(): array
     {
@@ -176,6 +178,7 @@ class NowPaymentsClient
 
     /**
      * Get available currencies
+     * @throws ApiException
      */
     public function getCurrencies(): array
     {
@@ -184,6 +187,7 @@ class NowPaymentsClient
 
     /**
      * Get merchant active currencies
+     * @throws ApiException
      */
     public function getMerchantCurrencies(): array
     {

--- a/src/Services/AbstractService.php
+++ b/src/Services/AbstractService.php
@@ -2,6 +2,7 @@
 
 namespace NowPayments\Services;
 
+use NowPayments\Exception\ValidationException;
 use NowPayments\NowPaymentsClient;
 use NowPayments\Exception\ApiException;
 use GuzzleHttp\Exception\RequestException;
@@ -122,7 +123,7 @@ abstract class AbstractService
      *
      * @param array $data The data to validate
      * @param array $requiredFields List of required field names
-     * @throws \InvalidArgumentException
+     * @throws ValidationException
      */
     protected function validateRequiredFields(array $data, array $requiredFields): void
     {
@@ -135,9 +136,7 @@ abstract class AbstractService
         }
         
         if (!empty($missing)) {
-            throw new \InvalidArgumentException(
-                'Missing required fields: ' . implode(', ', $missing)
-            );
+            throw new ValidationException('Missing required fields: ' . implode(', ', $missing));
         }
     }
-} 
+}

--- a/src/Services/ConversionsService.php
+++ b/src/Services/ConversionsService.php
@@ -2,6 +2,7 @@
 
 namespace NowPayments\Services;
 
+use NowPayments\Exception\ApiException;
 use NowPayments\Exception\ValidationException;
 
 /**
@@ -14,7 +15,7 @@ class ConversionsService extends AbstractService
      *
      * @param array $data Conversion data
      * @return array
-     * @throws ValidationException
+     * @throws ValidationException|ApiException
      */
     public function create(array $data): array
     {
@@ -28,10 +29,11 @@ class ConversionsService extends AbstractService
      *
      * @param string $conversionId Conversion ID
      * @return array
+     * @throws ApiException
      */
     public function getStatus(string $conversionId): array
     {
-        return $this->get("conversion/{$conversionId}");
+        return $this->get("conversion/$conversionId");
     }
 
     /**
@@ -39,6 +41,7 @@ class ConversionsService extends AbstractService
      *
      * @param array $filters Optional filters
      * @return array
+     * @throws ApiException
      */
     public function list(array $filters = []): array
     {
@@ -52,6 +55,7 @@ class ConversionsService extends AbstractService
      * @param string $toCurrency Target currency
      * @param float $amount Amount to convert
      * @return array
+     * @throws ValidationException|ApiException
      */
     public function createConversion(string $fromCurrency, string $toCurrency, float $amount): array
     {
@@ -67,6 +71,7 @@ class ConversionsService extends AbstractService
      *
      * @param float $amount Amount in BTC
      * @return array
+     * @throws ValidationException|ApiException
      */
     public function convertBtcToEth(float $amount): array
     {
@@ -78,6 +83,7 @@ class ConversionsService extends AbstractService
      *
      * @param float $amount Amount in ETH
      * @return array
+     * @throws ValidationException|ApiException
      */
     public function convertEthToBtc(float $amount): array
     {
@@ -89,6 +95,7 @@ class ConversionsService extends AbstractService
      *
      * @param float $amount Amount in BTC
      * @return array
+     * @throws ValidationException|ApiException
      */
     public function convertBtcToUsdt(float $amount): array
     {
@@ -100,6 +107,7 @@ class ConversionsService extends AbstractService
      *
      * @param float $amount Amount in ETH
      * @return array
+     * @throws ValidationException|ApiException
      */
     public function convertEthToUsdt(float $amount): array
     {
@@ -111,6 +119,7 @@ class ConversionsService extends AbstractService
      *
      * @param float $amount Amount in USDT
      * @return array
+     * @throws ValidationException|ApiException
      */
     public function convertUsdtToBtc(float $amount): array
     {
@@ -122,6 +131,7 @@ class ConversionsService extends AbstractService
      *
      * @param float $amount Amount in USDT
      * @return array
+     * @throws ValidationException|ApiException
      */
     public function convertUsdtToEth(float $amount): array
     {
@@ -135,6 +145,7 @@ class ConversionsService extends AbstractService
      * @param int $limit Number of conversions to return
      * @param int $offset Offset
      * @return array
+     * @throws ApiException
      */
     public function listByStatus(string $status, int $limit = 10, int $offset = 0): array
     {
@@ -152,6 +163,7 @@ class ConversionsService extends AbstractService
      * @param int $limit Number of conversions to return
      * @param int $offset Offset
      * @return array
+     * @throws ApiException
      */
     public function listByCurrency(string $currency, int $limit = 10, int $offset = 0): array
     {
@@ -167,6 +179,7 @@ class ConversionsService extends AbstractService
      *
      * @param string $conversionId Conversion ID
      * @return bool
+     * @throws ApiException
      */
     public function isCompleted(string $conversionId): bool
     {
@@ -179,6 +192,7 @@ class ConversionsService extends AbstractService
      *
      * @param string $conversionId Conversion ID
      * @return bool
+     * @throws ApiException
      */
     public function isPending(string $conversionId): bool
     {
@@ -191,6 +205,7 @@ class ConversionsService extends AbstractService
      *
      * @param string $conversionId Conversion ID
      * @return bool
+     * @throws ApiException
      */
     public function isFailed(string $conversionId): bool
     {

--- a/src/Services/CustodyService.php
+++ b/src/Services/CustodyService.php
@@ -2,10 +2,11 @@
 
 namespace NowPayments\Services;
 
+use NowPayments\Exception\ApiException;
 use NowPayments\Exception\ValidationException;
 
 /**
- * Service for custody (sub-account) operations
+ * Service for custody (subaccount) operations
  */
 class CustodyService extends AbstractService
 {
@@ -14,6 +15,7 @@ class CustodyService extends AbstractService
      *
      * @param array $data User data
      * @return array
+     * @throws ApiException
      */
     public function createUser(array $data = []): array
     {
@@ -25,10 +27,11 @@ class CustodyService extends AbstractService
      *
      * @param int $userId User ID
      * @return array
+     * @throws ApiException
      */
     public function getBalance(int $userId): array
     {
-        return $this->get("sub-partner/balance/{$userId}");
+        return $this->get("sub-partner/balance/$userId");
     }
 
     /**
@@ -36,6 +39,7 @@ class CustodyService extends AbstractService
      *
      * @param array $filters Optional filters
      * @return array
+     * @throws ApiException
      */
     public function listUsers(array $filters = []): array
     {
@@ -47,7 +51,7 @@ class CustodyService extends AbstractService
      *
      * @param array $data Payment data
      * @return array
-     * @throws ValidationException
+     * @throws ValidationException|ApiException
      */
     public function createPayment(array $data): array
     {
@@ -61,7 +65,7 @@ class CustodyService extends AbstractService
      *
      * @param array $data Transfer data
      * @return array
-     * @throws ValidationException
+     * @throws ValidationException|ApiException
      */
     public function transfer(array $data): array
     {
@@ -75,6 +79,7 @@ class CustodyService extends AbstractService
      *
      * @param array $filters Optional filters
      * @return array
+     * @throws ApiException
      */
     public function listTransfers(array $filters = []): array
     {
@@ -86,10 +91,11 @@ class CustodyService extends AbstractService
      *
      * @param string $transferId Transfer ID
      * @return array
+     * @throws ApiException
      */
     public function getTransfer(string $transferId): array
     {
-        return $this->get("sub-partner/transfer/{$transferId}");
+        return $this->get("sub-partner/transfer/$transferId");
     }
 
     /**
@@ -97,7 +103,7 @@ class CustodyService extends AbstractService
      *
      * @param array $data Withdrawal data
      * @return array
-     * @throws ValidationException
+     * @throws ValidationException|ApiException
      */
     public function withdraw(array $data): array
     {
@@ -112,6 +118,7 @@ class CustodyService extends AbstractService
      * @param string|null $externalId External ID
      * @param string|null $email Email address
      * @return array
+     * @throws ApiException
      */
     public function createUserAccount(?string $externalId = null, ?string $email = null): array
     {
@@ -136,6 +143,7 @@ class CustodyService extends AbstractService
      * @param float|null $amount Amount (optional)
      * @param string|null $trackId Track ID (optional)
      * @return array
+     * @throws ApiException|ValidationException
      */
     public function createDepositPayment(int $userId, string $currency, ?float $amount = null, ?string $trackId = null): array
     {
@@ -151,7 +159,7 @@ class CustodyService extends AbstractService
         if ($trackId !== null) {
             $data['track_id'] = $trackId;
         }
-        
+
         return $this->createPayment($data);
     }
 
@@ -163,6 +171,7 @@ class CustodyService extends AbstractService
      * @param string $currency Currency
      * @param float $amount Amount
      * @return array
+     * @throws ApiException|ValidationException
      */
     public function transferBetweenUsers(int $fromUserId, int $toUserId, string $currency, float $amount): array
     {
@@ -181,6 +190,7 @@ class CustodyService extends AbstractService
      * @param string $currency Currency
      * @param float $amount Amount
      * @return array
+     * @throws ApiException|ValidationException
      */
     public function transferToMaster(int $userId, string $currency, float $amount): array
     {
@@ -199,6 +209,7 @@ class CustodyService extends AbstractService
      * @param string $currency Currency
      * @param float $amount Amount
      * @return array
+     * @throws ApiException|ValidationException
      */
     public function transferFromMaster(int $userId, string $currency, float $amount): array
     {
@@ -219,6 +230,7 @@ class CustodyService extends AbstractService
      * @param string $address External address
      * @param array $options Additional options
      * @return array
+     * @throws ApiException|ValidationException
      */
     public function withdrawToAddress(int $userId, string $currency, float $amount, string $address, array $options = []): array
     {
@@ -239,6 +251,7 @@ class CustodyService extends AbstractService
      * @param string $currency Currency
      * @param float $amount Amount
      * @return array
+     * @throws ApiException|ValidationException
      */
     public function withdrawToMaster(int $userId, string $currency, float $amount): array
     {
@@ -256,6 +269,7 @@ class CustodyService extends AbstractService
      * @param int $limit Number of transfers to return
      * @param int $offset Offset
      * @return array
+     * @throws ApiException
      */
     public function listTransfersByUser(int $userId, int $limit = 10, int $offset = 0): array
     {
@@ -273,6 +287,7 @@ class CustodyService extends AbstractService
      * @param int $limit Number of transfers to return
      * @param int $offset Offset
      * @return array
+     * @throws ApiException
      */
     public function listTransfersByStatus(string $status, int $limit = 10, int $offset = 0): array
     {

--- a/src/Services/GeneralService.php
+++ b/src/Services/GeneralService.php
@@ -2,6 +2,8 @@
 
 namespace NowPayments\Services;
 
+use NowPayments\Exception\ApiException;
+
 /**
  * Service for general API operations
  */
@@ -11,6 +13,7 @@ class GeneralService extends AbstractService
      * Check API status
      *
      * @return array
+     * @throws ApiException
      */
     public function getStatus(): array
     {
@@ -21,6 +24,7 @@ class GeneralService extends AbstractService
      * Get all available currencies
      *
      * @return array
+     * @throws ApiException
      */
     public function getCurrencies(): array
     {
@@ -31,6 +35,7 @@ class GeneralService extends AbstractService
      * Get merchant active currencies
      *
      * @return array
+     * @throws ApiException
      */
     public function getMerchantCurrencies(): array
     {
@@ -41,6 +46,7 @@ class GeneralService extends AbstractService
      * Get full currency details
      *
      * @return array
+     * @throws ApiException
      */
     public function getFullCurrencies(): array
     {
@@ -53,6 +59,7 @@ class GeneralService extends AbstractService
      * @param string $currencyFrom Source currency
      * @param string $currencyTo Target currency
      * @return array
+     * @throws ApiException
      */
     public function getMinAmount(string $currencyFrom, string $currencyTo): array
     {
@@ -69,6 +76,7 @@ class GeneralService extends AbstractService
      * @param string $currencyFrom Source currency
      * @param string $currencyTo Target currency
      * @return array
+     * @throws ApiException
      */
     public function getEstimate(float $amount, string $currencyFrom, string $currencyTo): array
     {

--- a/src/Services/IpnService.php
+++ b/src/Services/IpnService.php
@@ -2,6 +2,8 @@
 
 namespace NowPayments\Services;
 
+use InvalidArgumentException;
+
 /**
  * Service for IPN (Instant Payment Notification) operations
  */
@@ -41,13 +43,14 @@ class IpnService extends AbstractService
      * @param string $requestBody The raw request body
      * @param string $signature The signature from X-NOWPAYMENTS-Sig header
      * @return bool
+     * @throws InvalidArgumentException
      */
     public function verifySignatureWithClientSecret(string $requestBody, string $signature): bool
     {
         $secret = $this->client->getIpnSecret();
         
         if ($secret === null) {
-            throw new \InvalidArgumentException('IPN secret not configured in client');
+            throw new InvalidArgumentException('IPN secret not configured in client');
         }
         
         return $this->verifySignature($requestBody, $signature, $secret);
@@ -82,7 +85,7 @@ class IpnService extends AbstractService
         $secret = $this->client->getIpnSecret();
         
         if ($secret === null) {
-            throw new \InvalidArgumentException('IPN secret not configured in client');
+            throw new InvalidArgumentException('IPN secret not configured in client');
         }
         
         return $this->processIpn($requestBody, $signature, $secret);

--- a/src/Services/PaymentsService.php
+++ b/src/Services/PaymentsService.php
@@ -2,6 +2,7 @@
 
 namespace NowPayments\Services;
 
+use NowPayments\Exception\ApiException;
 use NowPayments\Exception\ValidationException;
 
 /**
@@ -14,7 +15,7 @@ class PaymentsService extends AbstractService
      *
      * @param array $data Payment data
      * @return array
-     * @throws ValidationException
+     * @throws ValidationException|ApiException
      */
     public function create(array $data): array
     {
@@ -28,10 +29,11 @@ class PaymentsService extends AbstractService
      *
      * @param int $paymentId Payment ID
      * @return array
+     * @throws ApiException
      */
     public function getStatus(int $paymentId): array
     {
-        return $this->get("payment/{$paymentId}");
+        return $this->get("payment/$paymentId");
     }
 
     /**
@@ -39,6 +41,7 @@ class PaymentsService extends AbstractService
      *
      * @param array $filters Optional filters
      * @return array
+     * @throws ApiException
      */
     public function list(array $filters = []): array
     {
@@ -50,10 +53,11 @@ class PaymentsService extends AbstractService
      *
      * @param int $paymentId Payment ID
      * @return array
+     * @throws ApiException
      */
     public function updateEstimate(int $paymentId): array
     {
-        return $this->post("payment/{$paymentId}/update-merchant-estimate");
+        return $this->post("payment/$paymentId/update-merchant-estimate");
     }
 
     /**
@@ -61,7 +65,7 @@ class PaymentsService extends AbstractService
      *
      * @param array $data Invoice data
      * @return array
-     * @throws ValidationException
+     * @throws ValidationException|ApiException
      */
     public function createInvoice(array $data): array
     {
@@ -75,10 +79,11 @@ class PaymentsService extends AbstractService
      *
      * @param string $invoiceId Invoice ID
      * @return array
+     * @throws ApiException
      */
     public function getInvoiceStatus(string $invoiceId): array
     {
-        return $this->get("invoice/{$invoiceId}");
+        return $this->get("invoice/$invoiceId");
     }
 
     /**
@@ -86,7 +91,7 @@ class PaymentsService extends AbstractService
      *
      * @param array $data Payment data for invoice
      * @return array
-     * @throws ValidationException
+     * @throws ValidationException|ApiException
      */
     public function createInvoicePayment(array $data): array
     {
@@ -103,6 +108,7 @@ class PaymentsService extends AbstractService
      * @param string $payCurrency Cryptocurrency to pay in (e.g., 'btc')
      * @param array $options Additional options
      * @return array
+     * @throws ValidationException|ApiException
      */
     public function createPayment(
         float $priceAmount,
@@ -124,6 +130,7 @@ class PaymentsService extends AbstractService
      *
      * @param int $paymentId Payment ID
      * @return array
+     * @throws ApiException
      */
     public function getPayment(int $paymentId): array
     {
@@ -137,6 +144,7 @@ class PaymentsService extends AbstractService
      * @param int $limit Number of payments to return
      * @param int $page Page number
      * @return array
+     * @throws ApiException
      */
     public function listByStatus(string $status, int $limit = 10, int $page = 0): array
     {
@@ -154,6 +162,7 @@ class PaymentsService extends AbstractService
      * @param int $limit Number of payments to return
      * @param int $page Page number
      * @return array
+     * @throws ApiException
      */
     public function listByCurrency(string $currency, int $limit = 10, int $page = 0): array
     {
@@ -172,6 +181,7 @@ class PaymentsService extends AbstractService
      * @param int $limit Number of payments to return
      * @param int $page Page number
      * @return array
+     * @throws ApiException
      */
     public function listByDateRange(string $dateFrom, string $dateTo, int $limit = 10, int $page = 0): array
     {

--- a/src/Services/PayoutsService.php
+++ b/src/Services/PayoutsService.php
@@ -2,6 +2,7 @@
 
 namespace NowPayments\Services;
 
+use NowPayments\Exception\ApiException;
 use NowPayments\Exception\ValidationException;
 
 /**
@@ -14,7 +15,7 @@ class PayoutsService extends AbstractService
      *
      * @param array $data Payout data
      * @return array
-     * @throws ValidationException
+     * @throws ValidationException|ApiException
      */
     public function create(array $data): array
     {
@@ -37,10 +38,11 @@ class PayoutsService extends AbstractService
      * @param string $batchId Batch ID
      * @param string $code 2FA code
      * @return array
+     * @throws ApiException
      */
     public function verify(string $batchId, string $code): array
     {
-        return $this->post("payout/{$batchId}/verify", ['code' => $code]);
+        return $this->post("payout/$batchId/verify", ['code' => $code]);
     }
 
     /**
@@ -48,10 +50,11 @@ class PayoutsService extends AbstractService
      *
      * @param string $batchId Batch ID
      * @return array
+     * @throws ApiException
      */
     public function getStatus(string $batchId): array
     {
-        return $this->get("payout/{$batchId}");
+        return $this->get("payout/$batchId");
     }
 
     /**
@@ -59,6 +62,7 @@ class PayoutsService extends AbstractService
      *
      * @param array $filters Optional filters
      * @return array
+     * @throws ApiException
      */
     public function list(array $filters = []): array
     {
@@ -72,6 +76,7 @@ class PayoutsService extends AbstractService
      * @param string $currency Currency
      * @param string|null $extraId Extra ID (memo/tag)
      * @return array
+     * @throws ApiException
      */
     public function validateAddress(string $address, string $currency, ?string $extraId = null): array
     {
@@ -93,6 +98,7 @@ class PayoutsService extends AbstractService
      * @param array $withdrawals Array of withdrawal objects
      * @param array $options Additional options
      * @return array
+     * @throws ValidationException|ApiException
      */
     public function createPayout(array $withdrawals, array $options = []): array
     {
@@ -111,6 +117,7 @@ class PayoutsService extends AbstractService
      * @param float $amount Amount
      * @param array $options Additional options
      * @return array
+     * @throws ValidationException|ApiException
      */
     public function createSinglePayout(string $address, string $currency, float $amount, array $options = []): array
     {
@@ -132,6 +139,7 @@ class PayoutsService extends AbstractService
      * @param string $fiatCurrency Fiat currency
      * @param array $options Additional options
      * @return array
+     * @throws ValidationException|ApiException
      */
     public function createPayoutWithFiatAmount(
         string $address,
@@ -157,6 +165,7 @@ class PayoutsService extends AbstractService
      * @param int $limit Number of payouts to return
      * @param int $page Page number
      * @return array
+     * @throws ApiException
      */
     public function listByStatus(string $status, int $limit = 10, int $page = 0): array
     {
@@ -175,6 +184,7 @@ class PayoutsService extends AbstractService
      * @param int $limit Number of payouts to return
      * @param int $page Page number
      * @return array
+     * @throws ApiException
      */
     public function listByDateRange(string $dateFrom, string $dateTo, int $limit = 10, int $page = 0): array
     {
@@ -191,6 +201,7 @@ class PayoutsService extends AbstractService
      *
      * @param string $batchId Batch ID
      * @return bool
+     * @throws ApiException
      */
     public function isFinished(string $batchId): bool
     {
@@ -203,6 +214,7 @@ class PayoutsService extends AbstractService
      *
      * @param string $batchId Batch ID
      * @return bool
+     * @throws ApiException
      */
     public function isSending(string $batchId): bool
     {
@@ -215,6 +227,7 @@ class PayoutsService extends AbstractService
      *
      * @param string $batchId Batch ID
      * @return bool
+     * @throws ApiException
      */
     public function isFailed(string $batchId): bool
     {

--- a/src/Services/SubscriptionsService.php
+++ b/src/Services/SubscriptionsService.php
@@ -2,6 +2,7 @@
 
 namespace NowPayments\Services;
 
+use NowPayments\Exception\ApiException;
 use NowPayments\Exception\ValidationException;
 
 /**
@@ -14,7 +15,7 @@ class SubscriptionsService extends AbstractService
      *
      * @param array $data Plan data
      * @return array
-     * @throws ValidationException
+     * @throws ValidationException|ApiException
      */
     public function createPlan(array $data): array
     {
@@ -29,10 +30,11 @@ class SubscriptionsService extends AbstractService
      * @param string $planId Plan ID
      * @param array $data Update data
      * @return array
+     * @throws ApiException
      */
     public function updatePlan(string $planId, array $data): array
     {
-        return $this->patch("subscriptions/plans/{$planId}", $data);
+        return $this->patch("subscriptions/plans/$planId", $data);
     }
 
     /**
@@ -40,16 +42,18 @@ class SubscriptionsService extends AbstractService
      *
      * @param string $planId Plan ID
      * @return array
+     * @throws ApiException
      */
     public function getPlan(string $planId): array
     {
-        return $this->get("subscriptions/plans/{$planId}");
+        return $this->get("subscriptions/plans/$planId");
     }
 
     /**
      * List all subscription plans
      *
      * @return array
+     * @throws ApiException
      */
     public function listPlans(): array
     {
@@ -61,7 +65,7 @@ class SubscriptionsService extends AbstractService
      *
      * @param array $data Subscription data
      * @return array
-     * @throws ValidationException
+     * @throws ValidationException|ApiException
      */
     public function create(array $data): array
     {
@@ -75,10 +79,11 @@ class SubscriptionsService extends AbstractService
      *
      * @param string $subscriptionId Subscription ID
      * @return array
+     * @throws ApiException
      */
     public function getSubscription(string $subscriptionId): array
     {
-        return $this->get("subscriptions/{$subscriptionId}");
+        return $this->get("subscriptions/$subscriptionId");
     }
 
     /**
@@ -86,6 +91,7 @@ class SubscriptionsService extends AbstractService
      *
      * @param array $filters Optional filters
      * @return array
+     * @throws ApiException
      */
     public function list(array $filters = []): array
     {
@@ -97,10 +103,11 @@ class SubscriptionsService extends AbstractService
      *
      * @param string $subscriptionId Subscription ID
      * @return array
+     * @throws ApiException
      */
     public function cancel(string $subscriptionId): array
     {
-        return $this->delete("subscriptions/{$subscriptionId}");
+        return $this->delete("subscriptions/$subscriptionId");
     }
 
     /**
@@ -112,6 +119,7 @@ class SubscriptionsService extends AbstractService
      * @param string $currency Fiat currency
      * @param array $options Additional options
      * @return array
+     * @throws ValidationException|ApiException
      */
     public function createSubscriptionPlan(
         string $title,
@@ -137,6 +145,7 @@ class SubscriptionsService extends AbstractService
      * @param string $email Customer email
      * @param array $options Additional options
      * @return array
+     * @throws ValidationException|ApiException
      */
     public function createSubscription(string $planId, string $email, array $options = []): array
     {
@@ -155,6 +164,7 @@ class SubscriptionsService extends AbstractService
      * @param int $limit Number of subscriptions to return
      * @param int $page Page number
      * @return array
+     * @throws ApiException
      */
     public function listByPlan(string $planId, int $limit = 10, int $page = 0): array
     {
@@ -172,6 +182,7 @@ class SubscriptionsService extends AbstractService
      * @param int $limit Number of subscriptions to return
      * @param int $page Page number
      * @return array
+     * @throws ApiException
      */
     public function listByStatus(string $status, int $limit = 10, int $page = 0): array
     {
@@ -188,6 +199,7 @@ class SubscriptionsService extends AbstractService
      * @param string $planId Plan ID
      * @param float $amount New amount
      * @return array
+     * @throws ApiException
      */
     public function updatePlanAmount(string $planId, float $amount): array
     {
@@ -200,6 +212,7 @@ class SubscriptionsService extends AbstractService
      * @param string $planId Plan ID
      * @param int $intervalDay New interval in days
      * @return array
+     * @throws ApiException
      */
     public function updatePlanInterval(string $planId, int $intervalDay): array
     {


### PR DESCRIPTION
Thanks for creating this! I started a project that uses NOWPayments a few days ago, and this is super helpful.

There are some missing phpdoc @throws tags which results in IDE warnings when I try to add the requisite catch blocks. I've added them here. While adding them I noticed there were some unnecessary curly braces used when interpolating strings, so I removed those too.